### PR TITLE
Remove componentWillMount

### DIFF
--- a/lib/src/InteractableView.js
+++ b/lib/src/InteractableView.js
@@ -40,10 +40,6 @@ class WrappedAnimatedInteractableView extends Component {
     }
   }
 
-  componentWillMount() {
-    // this.chokeTheBridge();
-  }
-
   // this helps us verify that useNativeDriver actually works and we don't rely on the bridge
   chokeTheBridge() {
     let j = 0;


### PR DESCRIPTION
`componentWillMount` is deprecated and therefore warnings are shown when using RN 0.60+.

```
Warning: componentWillMount is deprecated and will be removed in the next major version. Use componentDidMount instead. As a temporary workaround, you can rename to UNSAFE_componentWillMount.

Please update the following components: WrappedAnimatedInteractableView
```

The lifecycle isn't used anymore so we can safely remove it.